### PR TITLE
Reworked MIWU to use interrupt binding

### DIFF
--- a/examples/src/bin/miwu_gpio.rs
+++ b/examples/src/bin/miwu_gpio.rs
@@ -6,17 +6,20 @@ use embassy_executor::Spawner;
 use embassy_npcx::gpio::{Level, Output, OutputOnly};
 use embassy_npcx::gpio_miwu::AwaitableInput;
 use embassy_npcx::interrupt::InterruptExt;
-use embassy_npcx::{self as hal, Config};
+use embassy_npcx::{self as hal, bind_interrupts, Config};
 use embedded_hal_async::digital::Wait;
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    WKINTG_1 => hal::miwu::InterruptHandler<hal::peripherals::MIWU1_73>;
+});
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     info!("To use, configure JP2 to '2' and press SW1. LED D8 should light up.");
 
-    let (p, _mode) = embassy_npcx::init_lpc(Config::default());
-
-    let mut button = AwaitableInput::new(p.PJ02, p.MIWU1_73);
+    let (p, _) = embassy_npcx::init_espi(Config::default());
+    let mut button = AwaitableInput::new(p.PJ02, p.MIWU1_73, Irqs);
     button.enable_pullup();
 
     let mut led = Output::<'_, OutputOnly>::new(p.PJ07, Level::High);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,10 @@
 
 pub mod cdcg;
 pub mod gpio;
+pub mod gpio_miwu;
+pub mod i2c;
 pub mod miwu;
 
-#[cfg(feature = "rt")]
-pub mod gpio_miwu;
-
-pub mod i2c;
 pub use npcx490m_pac as pac;
 
 #[non_exhaustive]


### PR DESCRIPTION
Decided to get rid of the 192 waker array, and instead use the embassy bind_interrupt method to instantiate the waker and interrupt handler on-demand. This significantly reduced the RAM footprint for the typical usecase.

It makes the worst case however very much worse, as I got rid of the bit-packed WuiIndex, and instead maintain a Waker ptr, port ptr, group and subgroup u8 in the AnyWakeInput. If this ever becomes relevant, we can go back to a bitpacked solution once more. In my opinion this cleans up the code a lot.